### PR TITLE
Do not pin device to version during preload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           set -euo pipefail
           # Preload the release that was just created, by commit to be sure it's the right one
-          "${BALENA_BIN}" preload "${{ steps.os_image.outputs.image_path }}" --fleet "${BALENA_FLEET}" --commit "${{ steps.deploy_release.outputs.release_commit }}"
+          "${BALENA_BIN}" preload "${{ steps.os_image.outputs.image_path }}" --fleet "${BALENA_FLEET}" --commit "${{ steps.deploy_release.outputs.release_commit }}" --no-pin-device-to-release
 
       - name: Compress image for GitHub release
         id: release_asset


### PR DESCRIPTION
This prevents an interactive prompt which causes the release workflow to hang.