### PR TITLE
Fix usb hotplugging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           IMAGE_PATH="gateway-${TAG_NAME}.img"
           rm -f "${IMAGE_PATH}"
           # Intel NUC uses balena's default flasher image, which can be preloaded directly.
-          "${BALENA_BIN}" os download "${BALENA_DEVICE_TYPE}" --output "${IMAGE_PATH}" --version latest
+          "${BALENA_BIN}" os download "${BALENA_DEVICE_TYPE}" --output "${IMAGE_PATH}" --version 6.11.13
           if [ ! -f "${IMAGE_PATH}" ]; then
             echo "Expected balenaOS image file was not created at ${IMAGE_PATH}"
             exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,10 @@ services:
     build: docker/usb-cgroup-helper
     restart: unless-stopped
     privileged: true
+    # Send SIGTERM to stop the container so it can clean up and exit cleanly
+    stop_signal: SIGTERM
+    # Give the container 10 seconds to stop, otherwise send a SIGKILL
+    stop_grace_period: 10s
     environment:
       - "GATEWAY_SERVICE=webthings-gateway"
     labels:

--- a/docker/usb-cgroup-helper/cgroup-allow.sh
+++ b/docker/usb-cgroup-helper/cgroup-allow.sh
@@ -100,6 +100,14 @@ apply_rules() {
     done
 }
 
+# Interrupt sleep and stop cleanly if SIGTERM sent 
+cleanup() {
+    log "received stop signal, cleaning up and exiting"
+    exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
 # ── main loop ────────────────────────────────────────────────────────
 
 log "starting (gateway service: ${GATEWAY_SERVICE})"


### PR DESCRIPTION
As a temporary workaround for #64, pin the release to balenaOS 6.11.13.

Also add some code to the usb-cgroup-helper image to allow a more graceful shutdown if it gets stuck in a loop.