### PR TITLE
Remove public SSH key injection for now and bump host and gateway versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,8 @@ jobs:
           set -euo pipefail
           IMAGE_PATH="gateway-${TAG_NAME}.img"
           rm -f "${IMAGE_PATH}"
-          # Intel NUC uses balena's default flasher image, which can be preloaded directly.
-          "${BALENA_BIN}" os download "${BALENA_DEVICE_TYPE}" --output "${IMAGE_PATH}" --version 6.11.13
+          # Download balenaOS image for device type
+          "${BALENA_BIN}" os download "${BALENA_DEVICE_TYPE}" --output "${IMAGE_PATH}" --version 6.12.3
           if [ ! -f "${IMAGE_PATH}" ]; then
             echo "Expected balenaOS image file was not created at ${IMAGE_PATH}"
             exit 1
@@ -96,8 +96,6 @@ jobs:
           "${BALENA_BIN}" os configure "${IMAGE_PATH}" --fleet "${BALENA_FLEET}" --device-type "${BALENA_DEVICE_TYPE}" --config-network ethernet
           # Set the default hostname of the OS image to gateway, using sudo and the stored absolute path of the binary
           sudo "${BALENA_BIN}" config write --drive "${IMAGE_PATH}" hostname gateway
-          # Add a public SSH key so anyone with the corresponding private key can SSH in
-          sudo "${BALENA_BIN}" config write --drive "${IMAGE_PATH}" os.sshKeys "[\"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAXfEChAW3pGzW19PKOLAyz/icmCRTL9klmA9h5x9Ef6 admin@krellian.com\"]"
           echo "image_path=${IMAGE_PATH}" >> "$GITHUB_OUTPUT"
 
       - name: Preload gateway release into image

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webthings-gateway",
-  "version": "2.1.0-beta.2+krellian.6",
+  "version": "2.1.0-beta.2+krellian.7",
   "description": "Web of Things gateway",
   "main": "build/app.js",
   "scripts": {


### PR DESCRIPTION
The public SSH key injection does not currently work correctly due to https://github.com/balena-io/balena-cli/issues/3108

Removing it for now and bumping both the host OS version and gateway version.